### PR TITLE
Update basisregister URL's in basisregisters.py

### DIFF
--- a/geopunt/basisregisters.py
+++ b/geopunt/basisregisters.py
@@ -4,8 +4,8 @@ from ..tools.web import getUrlData
 
 class adresMatch(object):
   def __init__(self):
-      self._gemUrl = "https://api.basisregisters.vlaanderen.be/v1/gemeenten/"
-      self._amUrl = "https://api.basisregisters.vlaanderen.be/v1/adresmatch"
+      self._gemUrl = "https://api.basisregisters.vlaanderen.be/v2/gemeenten/"
+      self._amUrl = "https://api.basisregisters.vlaanderen.be/v2/adresmatch"
 
   def gemeenten(self, langcode="nl", step=500, stop=1500):
       'Return all Flemish gemeenten (Municipalities), langcode= "nl", "fr", "de"' 


### PR DESCRIPTION
The V1 endpoints to request the list of gemeentes and to use the adresmatch have been disabled so this functionality doesn't work anymore. Needs to be updated to the V2 URL.